### PR TITLE
Drop support for Rust below v1.36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.26.0
+  - 1.36.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
to unblock #6 