### PR TITLE
CI: Update Rust to v1.46.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.36.0
+  - 1.46.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
this should be considered a breaking change, since it essentially drops support for older Rust releases.