### PR TITLE
Migrate to Actix 0.13 APIs, Tokio 1.x, and fix non-UTF-8 messages being dropped silently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /target
 **/*.rs.bk
 Cargo.lock
+
+/.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ actix = "0.13.0"
 actix-service = "2.0.2"
 actix-tls = "3.0.3"
 backoff = "0.4.0"
+bytes = "1.4.0"
+encoding_rs = "0.8.32"
 log = "0.4"
 tokio = { version = "1.28.0", features = ["rt", "net"] }
 tokio-util = { version = "0.7.8", features = ["codec"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ license = "MIT/Apache-2.0"
 exclude = [".gitignore", ".travis.yml"]
 
 [dependencies]
-actix = "0.10"
+actix = "0.13.0"
+actix-service = "2.0.2"
+actix-tls = "3.0.3"
 backoff = "0.2.1"
 log = "0.4"
-tokio = { version = "0.2", default-features=false, features=["tcp", "time", "signal", "io-util"] }
-tokio-util = { version = "0.3", features = ["codec"] }
+tokio = { version = "1.28.0", features = ["rt", "net"] }
+tokio-util = { version = "0.7.8", features = ["codec"] }
 
 [dev-dependencies]
 pretty_env_logger = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [".gitignore", ".travis.yml"]
 actix = "0.13.0"
 actix-service = "2.0.2"
 actix-tls = "3.0.3"
-backoff = "0.2.1"
+backoff = "0.4.0"
 log = "0.4"
 tokio = { version = "1.28.0", features = ["rt", "net"] }
 tokio-util = { version = "0.7.8", features = ["codec"] }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,0 +1,152 @@
+use bytes::{Buf, BufMut, BytesMut};
+use encoding_rs::WINDOWS_1252;
+use std::{cmp, fmt, io, str};
+use tokio_util::codec::{Decoder, Encoder};
+
+fn utf8(buf: &[u8]) -> String {
+    let utf8_attempt = str::from_utf8(buf);
+    if let Ok(utf8_value) = utf8_attempt {
+        // Probably plain ASCII text or a station that uses UTF-8 for name encoding
+        utf8_value.to_string()
+    } else {
+        // Some stations use CP 1252 for encoding their name, so try that as fallback when the
+        // message contained a sequence of bytes that is not valid UTF-8. This always succeeds.
+        let (s, _) = WINDOWS_1252.decode_without_bom_handling(buf);
+        s.to_string()
+    }
+}
+
+/// A simple [`Decoder`] and [`Encoder`] implementation which splits up OGN messages by \r\n.
+/// It was derived from tokio-util's LinesCodec.
+pub struct OGNCodec {
+    next_index: usize,
+    is_discarding: bool,
+}
+
+impl OGNCodec {
+    pub fn new() -> OGNCodec {
+        OGNCodec {
+            next_index: 0,
+            is_discarding: false,
+        }
+    }
+
+    pub fn max_length(&self) -> usize {
+        // An arbitrary but sane line limit to avoid memory exhaustion when no \r\n is ever received
+        4096
+    }
+}
+
+impl Decoder for OGNCodec {
+    type Item = String;
+    type Error = OGNCodecError;
+
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<String>, OGNCodecError> {
+        loop {
+            // Find start of \r\n in up to the next 256 characters
+            let mut crlf_offset: Option<usize> = None;
+            let read_to = cmp::min(self.max_length().saturating_add(2), buf.len());
+            if read_to == 0 {
+                return Ok(None);
+            }
+            for i in (self.next_index + 1)..read_to {
+                if buf[i - 1] == b'\r' && buf[i] == b'\n' {
+                    crlf_offset = Some(i - 1);
+                    break;
+                }
+            }
+
+            match (self.is_discarding, crlf_offset) {
+                (true, Some(offset)) => {
+                    // (via LinesCodec)
+                    buf.advance(offset + 2);
+                    self.is_discarding = false;
+                    self.next_index = 0;
+                }
+                (true, None) => {
+                    // (via LinesCodec)
+                    buf.advance(read_to);
+                    self.next_index = 0;
+                    if buf.is_empty() {
+                        return Ok(None);
+                    }
+                }
+                (false, Some(offset)) => {
+                    // Found a line!
+                    self.next_index = 0;
+                    let line = buf.split_to(offset + 2);
+                    let line = &line[..line.len() - 2];
+                    return Ok(Some(utf8(line).to_string()));
+                }
+                (false, None) if buf.len() > self.max_length() => {
+                    // (via LinesCodec)
+                    self.is_discarding = true;
+                    return Err(OGNCodecError::MaxLineLengthExceeded);
+                }
+                (false, None) => {
+                    // We didn't find a line or reach the length limit, so the next call will
+                    // resume searching at the current offset minus one to account for a trailing
+                    // \r character.
+                    self.next_index = read_to - 1;
+                    return Ok(None);
+                }
+            }
+        }
+    }
+
+    fn decode_eof(&mut self, buf: &mut BytesMut) -> Result<Option<String>, OGNCodecError> {
+        Ok(match self.decode(buf)? {
+            Some(frame) => Some(frame),
+            None => {
+                // No terminating newline - return remaining data, if any
+                if buf.is_empty() || buf == &b"\r"[..] {
+                    None
+                } else {
+                    self.next_index = 0;
+                    Some(utf8(buf).to_string())
+                }
+            }
+        })
+    }
+}
+
+impl<T> Encoder<T> for OGNCodec
+where
+    T: AsRef<str>,
+{
+    type Error = OGNCodecError;
+
+    fn encode(&mut self, line: T, buf: &mut BytesMut) -> Result<(), OGNCodecError> {
+        let line = line.as_ref();
+        buf.reserve(line.len() + 2);
+        buf.put(line.as_bytes());
+        buf.put_u8(b'\r');
+        buf.put_u8(b'\n');
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum OGNCodecError {
+    /// The maximum line length was exceeded.
+    MaxLineLengthExceeded,
+    /// An IO error occurred.
+    Io(io::Error),
+}
+
+impl fmt::Display for OGNCodecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OGNCodecError::MaxLineLengthExceeded => write!(f, "max line length exceeded"),
+            OGNCodecError::Io(e) => write!(f, "I/O error: {}", e),
+        }
+    }
+}
+
+impl From<io::Error> for OGNCodecError {
+    fn from(e: io::Error) -> OGNCodecError {
+        OGNCodecError::Io(e)
+    }
+}
+
+impl std::error::Error for OGNCodecError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,11 @@ impl OGNActor {
         let mut backoff = ExponentialBackoff::default();
         backoff.max_elapsed_time = None;
 
-        OGNActor { recipient, backoff, writer: None }
+        OGNActor {
+            recipient,
+            backoff,
+            writer: None,
+        }
     }
 
     /// Schedule sending a "keep alive" message to the server every 30sec
@@ -74,10 +78,7 @@ impl Actor for OGNActor {
 
                         format!(
                             "user {} pass {} vers {} {}",
-                            username,
-                            password,
-                            app_name,
-                            app_version,
+                            username, password, app_name, app_version,
                         )
                     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use actix_service::Service;
 use actix_tls::connect::Connector;
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
-use log::{error, info, trace, warn};
+use log::{debug, error, info, trace, warn};
 use tokio::io::WriteHalf;
 use tokio::net::TcpStream;
 use tokio_util::codec::{FramedRead, LinesCodec, LinesCodecError};
@@ -40,9 +40,11 @@ impl OGNActor {
     /// Schedule sending a "keep alive" message to the server every 30sec
     fn schedule_keepalive(ctx: &mut Context<Self>) {
         ctx.run_later(Duration::from_secs(30), |act, ctx| {
-            info!("Sending keepalive to OGN server");
             if let Some(ref mut writer) = act.writer {
+                debug!("Sending keepalive to OGN server");
                 writer.write("# keep alive".to_string());
+            } else {
+                warn!("Cannot send keepalive to OGN server, writer not set");
             }
             OGNActor::schedule_keepalive(ctx);
         });


### PR DESCRIPTION
This PR updates dependencies (see Cargo.toml) and resolves an issue where `LinesCodec`'s decoder would return an error for non-UTF-8 message payloads, and Actix would silently drop the message in response. It is not backwards-compatible with the currently release version 0.4 due to Actix and Tokio being backwards-incompatible.

The following and comparable messages where stations used a name encoded with CP 1252 would be dropped:

```
|464e5446 43393030 323e4f47 4e464e54| FNTFC9002>OGNFNT 00000000
|2c714153 2c475853 74477267 6e3a3e31| ,qAS,GXStGrgn:>1 00000010
|31313031 3768204e 616d653d 2257696e| 11017h Name="Win 00000020
|643a46fc 7273742d 53fc6422 20362e36| d:F.rst-S.d" 6.6 00000030
|6442|                                dB               00000040
                                                       00000042
```

The cause was that ü encodes to 0xFC under CP 1252, which results in Rust's `str::from_utf8` to fail validation in `LinesCodec`, and old Actix versions would silently discard the error without stopping the affected actor. I noticed this because new Actix versions actually do stop the actor. This PR also adds code to log other I/O errors before the actor is stopped.

Steps to reproduce: Run `cargo run --example connect | grep 'Name='` on this branch vs. master, and observe that after a few minutes `Wind:Fürst-Süd` has several status lines in the output of this branch, versus none in master.